### PR TITLE
Fix affichage Text notePad + Text TodoList

### DIFF
--- a/Application/src/components/atoms/styles/TextInputTemplate.tsx
+++ b/Application/src/components/atoms/styles/TextInputTemplate.tsx
@@ -1,9 +1,11 @@
 import { ReactNode } from 'react';
+import { TextInput } from 'react-native';
 import { TextInput as PaperTextInput } from 'react-native-paper';
 import { Props as PaperTextInputProps } from 'react-native-paper/src/components/TextInput/TextInput';
 
 export default function TextInputTemplate(
   props: Readonly<PaperTextInputProps>
 ): ReactNode {
-  return <PaperTextInput {...props} />;
+  return <PaperTextInput {...props} 
+      render={props.multiline ? (innerProps) => <TextInput {...innerProps} style={{paddingTop: 9, paddingBottom:9, height:70, width:'80%'}}></TextInput> : undefined }/>
 }

--- a/Application/src/components/molecules/CheckboxTemplate.tsx
+++ b/Application/src/components/molecules/CheckboxTemplate.tsx
@@ -1,7 +1,7 @@
 import { IconButton, IconButtonProps } from 'react-native-paper';
 
 interface IconOverrideProps {
-  iconButton: IconButtonProps;
+  iconButton?: IconButtonProps;
   status: 'checked' | 'unchecked';
   onPress: () => void;
 }

--- a/Application/src/components/pages/Notes/NoteList.tsx
+++ b/Application/src/components/pages/Notes/NoteList.tsx
@@ -1,4 +1,5 @@
-import React, { ReactNode, useEffect, useState } from 'react';
+import { ReactNode, useEffect, useState } from 'react';
+import { StyleSheet } from 'react-native';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { StackParamList } from '../../../navigation/RootStack';
 import {
@@ -9,10 +10,12 @@ import {
 import { ApolloClient, useApolloClient } from '@apollo/client';
 import SurfaceTemplate from '../../molecules/SurfaceTemplate';
 import { Alert, FlatList, View } from 'react-native';
-import { TextInput } from 'react-native-paper';
 import ButtonTemplate from '../../atoms/styles/ButtonTemplate';
 import { theme } from '../../organisms/OwnPaperProvider';
 import { useIsFocused } from '@react-navigation/native';
+import TextTemplate from '../../atoms/styles/TextTemplate';
+import { TouchableOpacity } from 'react-native-gesture-handler';
+import { Icon } from 'react-native-paper';
 
 type Props = NativeStackScreenProps<StackParamList>;
 
@@ -48,21 +51,11 @@ export default function NoteList(props: Readonly<Props>): ReactNode {
 
   const renderNotes = (renderNoteProps: RenderNoteProps) => {
     return (
-      <View>
-        <SurfaceTemplate
-          style={{ flexDirection: 'row', flex: 1, borderWidth: 1 }}
-        >
           <View
-            style={{
-              alignContent: 'center',
-              flexDirection: 'row',
-              alignSelf: 'stretch',
-              flex: 1,
-              display: 'flex',
-            }}
+            style={styles.flexContainer}
           >
-            <ButtonTemplate
-              style={{ flex: 1, alignSelf: 'flex-start', position: 'relative' }}
+            <TouchableOpacity
+              style={[styles.flexItem, {flex:1, flexDirection:"row"}]}
               onPress={(): void => {
                 GetNote(client, renderNoteProps.item.id).then(currentNote => {
                   return props.navigation.navigate('Bloc-Notes', {
@@ -70,14 +63,19 @@ export default function NoteList(props: Readonly<Props>): ReactNode {
                   });
                 });
               }}
-              mode="text"
-            >
-              {renderNoteProps.item.title}
-            </ButtonTemplate>
-            <TextInput.Icon
-              icon={'trash-can'}
-              color={theme.colors.primary}
-              style={{ alignSelf: 'flex-start', position: 'relative' }}
+              >
+              <TextTemplate
+                style={{verticalAlign:'middle', marginRight:10}}
+                variant='titleMedium'>
+                {renderNoteProps.item.title}
+              </TextTemplate>
+              <Icon
+                size={35}
+                source={'note-edit'}
+                color={theme.colors.primary}/>
+            </TouchableOpacity>
+            <TouchableOpacity
+            style={[styles.flexItem, {flexShrink:8}]}
               onPress={(): void => {
                 Alert.alert(
                   `Suppression de ${renderNoteProps.item.title}`,
@@ -92,15 +90,17 @@ export default function NoteList(props: Readonly<Props>): ReactNode {
                     },
                   ]
                 );
-              }}
+              }}>
+            <Icon
+              size={35}
+              source={'trash-can'}
+              color={theme.colors.secondary}
             />
+            </TouchableOpacity>
           </View>
-        </SurfaceTemplate>
-      </View>
     );
   };
   return (
-    <View style={{ flex: 1, padding: 10 }}>
       <SurfaceTemplate>
         <ButtonTemplate
           onPress={(): void => {
@@ -109,10 +109,22 @@ export default function NoteList(props: Readonly<Props>): ReactNode {
         >
           Ajouter
         </ButtonTemplate>
+        <FlatList 
+          data={notes} 
+          renderItem={renderNotes}/>
       </SurfaceTemplate>
-      <SurfaceTemplate style={{ flex: 5 }}>
-        <FlatList data={notes} renderItem={renderNotes} />
-      </SurfaceTemplate>
-    </View>
   );
 }
+
+const styles = StyleSheet.create({
+  flexContainer: {
+    borderWidth:1,
+    borderRadius:50,
+    margin:5,
+    justifyContent:'flex-end',
+    flexDirection:'row',
+  },
+  flexItem: {
+    alignSelf:'center'
+  }
+});

--- a/Application/src/components/pages/Todo/TodoList.tsx
+++ b/Application/src/components/pages/Todo/TodoList.tsx
@@ -115,9 +115,8 @@ export default function TodoList(props: Readonly<Props>): ReactNode {
               />
             }
             mode="outlined"
-            style={{ flex: 1, paddingBottom: 0, paddingTop: 0 }}
+            style={{ flex: 1, pointerEvents:'none'}}
             multiline={true}
-            editable={false}
             onChangeText={edit => (item.content = edit)}
             value={item.content}
             outlineStyle={{


### PR DESCRIPTION
Fix de l'affichage pour la Liste toute douce et la liste des blocs notes 

![image](https://github.com/HiroKX/planifecation/assets/27964078/5771d244-f284-4c81-8e97-f70da593d9de)

![image](https://github.com/HiroKX/planifecation/assets/27964078/63e390bf-071f-4ed9-8281-896c38f7c234)

L'affichage des Todo pourrait être plus optimisé de la même manière que les Notes -> Mettre un TextTemplate plutôt qu'un TextInputTemplate. Sauf si l'on souhaite éditer un Todo une fois créé ? A voir par la suite